### PR TITLE
Fix wrapped-token auth method

### DIFF
--- a/request.go
+++ b/request.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"github.com/franela/goreq"
 	"io"
 	"io/ioutil"
@@ -25,14 +24,4 @@ func (r VaultRequest) Do() (*goreq.Response, error) {
 		resp, err = r.Request.Do()
 	}
 	return resp, err
-}
-
-type VaultWrappedResponse struct {
-	Data struct {
-		WrappedSecret string `json:"response"`
-	} `json:"data"`
-}
-
-func (vr *VaultWrappedResponse) Unwrap(v interface{}) error {
-	return json.Unmarshal([]byte(vr.Data.WrappedSecret), v)
 }


### PR DESCRIPTION
The ability to use a wrapped token is not working for current versions of Vault (at least 0.7.0) because /cubbyhole/response is no longer accessible. Hence:

curl -X PUT -H 'X-Vault-Token: b87bb5db-b20c-7a62-cd86-2a11dd7b5dd0' http://192.168.2.16:8200/v1/cubbyhole/response
{"errors":["permission denied"]}

Vault Gatekeeper Mesos likewise returns a 403 Permission Denied when trying to unwrap the token.

The endpoint that should be used is /sys/wrapping/unwrap:

curl -X PUT -H 'X-Vault-Token: b87bb5db-b20c-7a62-cd86-2a11dd7b5dd0' http://192.168.2.16:8200/v1/sys/wrapping/unwrap
{"request_id":"e96bad31-a04f-b542-7757-f187e943bfe2","lease_id":"","renewable":false,"lease_duration":0,"data":null,"wrap_info":null,"warnings":null,"auth":{"client_token":"44a7998a-93aa-6f7d-db7f-52aacf36c916","accessor":"269f17ca-ff43-2b33-2502-bd20fbdfe7c4","policies":["vgm_read_dev","vgm_token_create"],"metadata":null,"lease_duration":2764800,"renewable":true}}

This pull request uses the working unwrap endpoint and adjusts to the change in the data structure returned.