### PR TITLE
Added support for building different OS binaries

### DIFF
--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -127,7 +127,7 @@ func init() {
 
 	flag.IntVar(&config.SealHttpStatus, "seal-http-status", func() int {
 		b, err := strconv.ParseInt(defaultEnvVar("SEAL_HTTP_STATUS", "200"), 10, 0)
-		if err == nil {
+		if err != nil {
 			return 200
 		} else {
 			return int(b)


### PR DESCRIPTION
Added small improvements like ability to build per-OS binaries and code refactoring to consolidate common functions needed for better metrics integration.

Added support for go-kit/metrics library to enable future enhancements of adding various monitoring providers like StatsD, Prometheus, Graphite or DataDog (which is already added part of this PR, along with Go's default `expvar` metrics)