### PR TITLE
Enable wildcard with prefix.

### DIFF
--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -36,6 +36,10 @@ const samplePolicy = `{
 	"mesos:framework:task2":{
 		"roles":["mesos_framework_task2"],
 		"num_uses":1
+	},
+	"mesos:framework:service/*": {
+	    "roles":["mesos_framework_service"],
+	    "num_uses":1
 	}
 }`
 
@@ -77,6 +81,10 @@ func TestSamplePolicy(t *testing.T) {
 
 		if pass, expected, actual := shouldContainAll(mustGet(pols.Get("mesos:jamp")), "wildcard", "mesos_child"); !pass {
 			t.Fatalf("Test of '%s' failed. Expected: %v Had: %v", "mesos:jamp", expected, actual)
+		}
+
+		if pass, expected, actual := shouldContainAll(mustGet(pols.Get("mesos:framework:service/instance-1")), "wildcard", "mesos_child", "mesos_framework_child", "mesos_framework_service"); !pass {
+			t.Fatalf("Test of '%s' failed. Expected: %v Had: %v", "mesos:framework:service/instance-1", expected, actual)
 		}
 
 		if pass, _, actual := shouldContainAll(mustGet(pols.Get("mesos:framework:task2")), "mesos_framework_task"); pass {


### PR DESCRIPTION
Use case:

We use the Aurora scheduler in Mesos which assign tasks names using a
jobkey which consists of: "role/environment/jobname".  We often end up
in a scenario where we want all jobs running under a given "role" or
"role/environment" combination to have access to a Vault role.  Under
the current implementation this would require us to iterate all of the
possible combination and install policy files.

Previous versions of Vault gatekeeper allowed us to do wildcards with
prefixes as they used a simple glob match.  Moving to the radix tree
implementation broke this behaviour.

This patch changes the matching behaviour slightly.  Whenever we detect
a wildcard match we flag the policy as such.

When performing policy matching for wildcards we do a prefix search,
rather than looking for the last character being ":". Policy matching
for non wildcard policies is unchanged.

No changes to the radix tree structure are required.